### PR TITLE
Chore: remove cli constructor in tests

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,42 +1,37 @@
 package filclient
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
 
 func TestExportFile(t *testing.T) {
+	ctx := context.TODO()
 	outputFilename := path.Join(t.TempDir() + "export-test")
 
-	app := cli.NewApp()
-	app.Action = func(ctx *cli.Context) error {
-		client, miner, _, fc, closer := initEnsemble(t, ctx)
-		defer closer()
+	client, miner, _, fc, closer := initEnsemble(t, ctx)
+	defer closer()
 
-		// Create a dummy deal
-		importRes := genDummyDeal(ctx.Context, t, client, miner)
+	// Create a dummy deal
+	importRes := genDummyDeal(ctx, t, client, miner)
 
-		// Transfer dummy deal into the client
-		fmt.Printf("Transferring...\n")
-		transfer, err := fc.MinerByAddress(miner.ActorAddr).StartRetrievalTransfer(ctx.Context, importRes.Root)
-		require.NoError(t, err)
-		<-transfer.Done()
-		fmt.Printf("Finished transferring\n")
+	// Transfer dummy deal into the client
+	fmt.Printf("Transferring...\n")
+	transfer, err := fc.MinerByAddress(miner.ActorAddr).StartRetrievalTransfer(ctx, importRes.Root)
+	require.NoError(t, err)
+	<-transfer.Done()
+	fmt.Printf("Finished transferring\n")
 
-		// Export to file and check that it exists
-		fc.ExportToFile(ctx.Context, importRes.Root, outputFilename, false)
-		outFile, err := os.Stat(outputFilename)
+	// Export to file and check that it exists
+	require.NoError(t, fc.ExportToFile(ctx, importRes.Root, outputFilename, false))
+	outFile, err := os.Stat(outputFilename)
 
-		require.NoError(t, err)
-		require.Greater(t, outFile.Size(), int64(0))
+	require.NoError(t, err)
+	require.Greater(t, outFile.Size(), int64(0))
 
-		return nil
-	}
-
-	require.NoError(t, app.Run([]string{""}))
 }

--- a/miners_test.go
+++ b/miners_test.go
@@ -1,41 +1,33 @@
 package filclient
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
 
 func TestMinerVersion(t *testing.T) {
-	app := cli.NewApp()
-	app.Action = func(ctx *cli.Context) error {
-		_, miner, _, fc, closer := initEnsemble(t, ctx)
-		defer closer()
+	ctx := context.TODO()
 
-		version, err := fc.MinerByAddress(miner.ActorAddr).Version(ctx.Context)
-		require.NoError(t, err)
-		fmt.Printf("Found miner version: %s\n", version)
+	_, miner, _, fc, closer := initEnsemble(t, ctx)
+	defer closer()
 
-		return nil
-	}
-	require.NoError(t, app.Run([]string{""}))
+	version, err := fc.MinerByAddress(miner.ActorAddr).Version(ctx)
+	require.NoError(t, err)
+	fmt.Printf("Found miner version: %s\n", version)
+
 }
 
 func TestMinerAddressToPeerID(t *testing.T) {
-	app := cli.NewApp()
-	app.Action = func(ctx *cli.Context) error {
-		_, miner, _, fc, closer := initEnsemble(t, ctx)
-		defer closer()
+	ctx := context.TODO()
+	_, miner, _, fc, closer := initEnsemble(t, ctx)
+	defer closer()
 
-		minerPeerID, err := fc.MinerByAddress(miner.ActorAddr).PeerID(ctx.Context)
-		require.NoError(t, err)
-		fmt.Printf("Mapped miner address %s to peer ID %s\n", miner.ActorAddr, minerPeerID)
-
-		return nil
-	}
-	require.NoError(t, app.Run([]string{""}))
+	minerPeerID, err := fc.MinerByAddress(miner.ActorAddr).PeerID(ctx)
+	require.NoError(t, err)
+	fmt.Printf("Mapped miner address %s to peer ID %s\n", miner.ActorAddr, minerPeerID)
 }
 
 // TODO(@elijaharita): peer id -> address mapping is not functional yet

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,25 +1,21 @@
 package filclient
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
 
 func TestQueryStorageAsk(t *testing.T) {
-	app := cli.NewApp()
-	app.Action = func(ctx *cli.Context) error {
-		_, miner, _, fc, closer := initEnsemble(t, ctx)
-		defer closer()
+	ctx := context.TODO()
+	_, miner, _, fc, closer := initEnsemble(t, ctx)
+	defer closer()
 
-		ask, _, err := fc.MinerByAddress(miner.ActorAddr).QueryStorageAskUnchecked(ctx.Context)
-		require.NoError(t, err)
+	ask, _, err := fc.MinerByAddress(miner.ActorAddr).QueryStorageAskUnchecked(ctx)
+	require.NoError(t, err)
 
-		fmt.Printf("Storage ask: %#v\n", ask)
+	fmt.Printf("Storage ask: %#v\n", ask)
 
-		return nil
-	}
-	require.NoError(t, app.Run([]string{""}))
 }


### PR DESCRIPTION
Edited the test `initEnsemble` function to take a regular `context` (not `cli.Context`), and updated all tests to match. They're much simpler now without the boilerplate. 

Everything's still passing so I think it worked! 