### PR TITLE
chore: rename miner -> storage provider everywhere

### DIFF
--- a/cmd/filctl/main.go
+++ b/cmd/filctl/main.go
@@ -57,7 +57,7 @@ func main() {
 				&cli.StringFlag{
 					Name:    "provider",
 					Aliases: []string{"p", "miner", "m"},
-					Usage:   "The provider address or peer ID",
+					Usage:   "The storage provider address or peer ID",
 				},
 				&cli.StringFlag{
 					Name:    "output",
@@ -261,17 +261,17 @@ func cmdRetrieve(ctx *cli.Context) error {
 	queryOnly := ctx.Bool("query")
 
 	// Parse the provider handle
-	var handle *filclient.MinerHandle
+	var handle *filclient.StorageProviderHandle
 	addr, err := address.NewFromString(ctx.String("provider"))
 	if err != nil {
 		peerID, err2 := peer.Decode(ctx.String("provider"))
 		if err2 != nil {
 			return fmt.Errorf("could not parse provider string as addr (%v) or peer ID (%v)", err, err2)
 		} else {
-			handle = filctl.client.MinerByPeerID(peerID)
+			handle = filctl.client.StorageProviderByPeerID(peerID)
 		}
 	} else {
-		handle = filctl.client.MinerByAddress(addr)
+		handle = filctl.client.StorageProviderByAddress(addr)
 	}
 
 	// Parse the payload CID

--- a/export_test.go
+++ b/export_test.go
@@ -22,7 +22,7 @@ func TestExportFile(t *testing.T) {
 
 	// Transfer dummy deal into the client
 	fmt.Printf("Transferring...\n")
-	transfer, err := fc.MinerByAddress(miner.ActorAddr).StartRetrievalTransfer(ctx, importRes.Root)
+	transfer, err := fc.StorageProviderByAddress(miner.ActorAddr).StartRetrievalTransfer(ctx, importRes.Root)
 	require.NoError(t, err)
 	<-transfer.Done()
 	fmt.Printf("Finished transferring\n")

--- a/retrieval.go
+++ b/retrieval.go
@@ -94,7 +94,7 @@ func (transfer *RetrievalTransfer) Size() uint64 {
 	return transfer.size
 }
 
-func (handle *MinerHandle) QueryRetrievalAsk(ctx context.Context, payloadCid cid.Cid) (retrievalmarket.QueryResponse, error) {
+func (handle *StorageProviderHandle) QueryRetrievalAsk(ctx context.Context, payloadCid cid.Cid) (retrievalmarket.QueryResponse, error) {
 	const protocol = "/fil/retrieval/qry/1.0.0"
 
 	req := retrievalmarket.Query{PayloadCID: payloadCid}
@@ -107,7 +107,7 @@ func (handle *MinerHandle) QueryRetrievalAsk(ctx context.Context, payloadCid cid
 }
 
 // Start running a retrieval
-func (handle *MinerHandle) StartRetrievalTransfer(
+func (handle *StorageProviderHandle) StartRetrievalTransfer(
 	ctx context.Context,
 	payloadCid cid.Cid,
 	options ...RetrievalOption,

--- a/retrieval_test.go
+++ b/retrieval_test.go
@@ -27,7 +27,7 @@ func TestQueryRetrievalAsk(t *testing.T) {
 
 	importRes := genDummyDeal(ctx, t, client, miner)
 
-	ask, err := fc.MinerByAddress(miner.ActorAddr).QueryRetrievalAsk(ctx, importRes.Root)
+	ask, err := fc.StorageProviderByAddress(miner.ActorAddr).QueryRetrievalAsk(ctx, importRes.Root)
 	require.NoError(t, err)
 
 	require.Equal(t, ask.Status, retrievalmarket.QueryResponseAvailable, "Retrieval ask: %#v", ask)
@@ -45,7 +45,7 @@ func TestRetrievalTransfer(t *testing.T) {
 
 	// Run the transfer
 	fmt.Printf("Transferring...\n")
-	transfer, err := fc.MinerByAddress(miner.ActorAddr).StartRetrievalTransfer(ctx, importRes.Root)
+	transfer, err := fc.StorageProviderByAddress(miner.ActorAddr).StartRetrievalTransfer(ctx, importRes.Root)
 	require.NoError(t, err)
 	<-transfer.Done()
 	fmt.Printf("Finished transferring\n")

--- a/storage.go
+++ b/storage.go
@@ -15,7 +15,7 @@ import (
 // func (handle *MinerHandle) QueryStorageAsk(ctx context.Context) (storagemarket.StorageAsk, error) {}
 
 // Queries a storage ask, returning the signature without validating it
-func (handle *MinerHandle) QueryStorageAskUnchecked(ctx context.Context) (storagemarket.StorageAsk, crypto.Signature, error) {
+func (handle *StorageProviderHandle) QueryStorageAskUnchecked(ctx context.Context) (storagemarket.StorageAsk, crypto.Signature, error) {
 	const protocol = "/fil/storage/ask/1.1.0"
 
 	req := network.AskRequest{Miner: handle.addr}

--- a/storage_test.go
+++ b/storage_test.go
@@ -13,7 +13,7 @@ func TestQueryStorageAsk(t *testing.T) {
 	_, miner, _, fc, closer := initEnsemble(t, ctx)
 	defer closer()
 
-	ask, _, err := fc.MinerByAddress(miner.ActorAddr).QueryStorageAskUnchecked(ctx)
+	ask, _, err := fc.StorageProviderByAddress(miner.ActorAddr).QueryStorageAskUnchecked(ctx)
 	require.NoError(t, err)
 
 	fmt.Printf("Storage ask: %#v\n", ask)

--- a/storageproviders.go
+++ b/storageproviders.go
@@ -24,9 +24,9 @@ var (
 	ErrCBORReadFailed        = errors.New("CBOR read failed")
 )
 
-// A miner handle contains all the functions used to interact with the miner,
+// A storage provider handle contains all the functions used to interact with the storage provider,
 // and facilitates mapping between addresses and peer IDs
-type MinerHandle struct {
+type StorageProviderHandle struct {
 	// WARNING: may be uninitialized - use .Address()
 	addr address.Address
 	// WARNING: may be uninitialized - use .PeerID()
@@ -34,15 +34,15 @@ type MinerHandle struct {
 	client *Client
 }
 
-func (client *Client) MinerByAddress(addr address.Address) *MinerHandle {
-	return &MinerHandle{
+func (client *Client) StorageProviderByAddress(addr address.Address) *StorageProviderHandle {
+	return &StorageProviderHandle{
 		addr:   addr,
 		client: client,
 	}
 }
 
-func (client *Client) MinerByPeerID(peerID peer.ID) *MinerHandle {
-	return &MinerHandle{
+func (client *Client) StorageProviderByPeerID(peerID peer.ID) *StorageProviderHandle {
+	return &StorageProviderHandle{
 		peerID: peerID,
 		client: client,
 	}
@@ -52,7 +52,7 @@ func (client *Client) MinerByPeerID(peerID peer.ID) *MinerHandle {
 //
 // In the future, this function may be able to derive the address from the peer
 // ID
-func (handle *MinerHandle) Address(ctx context.Context) (address.Address, error) {
+func (handle *StorageProviderHandle) Address(ctx context.Context) (address.Address, error) {
 	if handle.addr == address.Undef {
 		return address.Undef, fmt.Errorf("peer ID to address mapping is not yet implemented")
 	}
@@ -62,7 +62,7 @@ func (handle *MinerHandle) Address(ctx context.Context) (address.Address, error)
 
 // Returns the peer ID of the provider, looking it up on chain using the address
 // if not already stored
-func (handle *MinerHandle) PeerID(ctx context.Context) (peer.ID, error) {
+func (handle *StorageProviderHandle) PeerID(ctx context.Context) (peer.ID, error) {
 	info, err := handle.client.api.StateMinerInfo(ctx, handle.addr, types.EmptyTSK)
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrLotusError, err)
@@ -78,7 +78,7 @@ func (handle *MinerHandle) PeerID(ctx context.Context) (peer.ID, error) {
 }
 
 // Looks up the version string of the miner
-func (handle *MinerHandle) Version(ctx context.Context) (string, error) {
+func (handle *StorageProviderHandle) Version(ctx context.Context) (string, error) {
 	peer, err := handle.Connect(ctx)
 	if err != nil {
 		return "", err
@@ -92,8 +92,8 @@ func (handle *MinerHandle) Version(ctx context.Context) (string, error) {
 	return version.(string), nil
 }
 
-// Opens a P2P stream to the miner
-func (handle *MinerHandle) stream(ctx context.Context, protocols ...protocol.ID) (network.Stream, error) {
+// Opens a P2P stream to the storage provider
+func (handle *StorageProviderHandle) stream(ctx context.Context, protocols ...protocol.ID) (network.Stream, error) {
 	peer, err := handle.Connect(ctx)
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func (handle *MinerHandle) stream(ctx context.Context, protocols ...protocol.ID)
 // ideal for multiple requests
 //
 // TODO(@elijaharita): generics
-func (handle *MinerHandle) runSingleRPC(ctx context.Context, req interface{}, resp interface{}, protocols ...protocol.ID) error {
+func (handle *StorageProviderHandle) runSingleRPC(ctx context.Context, req interface{}, resp interface{}, protocols ...protocol.ID) error {
 	stream, err := handle.stream(ctx, protocols...)
 	if err != nil {
 		return err
@@ -135,11 +135,11 @@ func (handle *MinerHandle) runSingleRPC(ctx context.Context, req interface{}, re
 	return nil
 }
 
-// Makes sure that the miner is connected
+// Makes sure that the storage provider is connected
 //
 // BEHAVIOR CHANGE - no longer errors on invalid multiaddr if at least one valid
 // multiaddr exists
-func (handle *MinerHandle) Connect(ctx context.Context) (peer.ID, error) {
+func (handle *StorageProviderHandle) Connect(ctx context.Context) (peer.ID, error) {
 	info, err := handle.client.api.StateMinerInfo(ctx, handle.addr, types.EmptyTSK)
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrLotusError, err)

--- a/storageproviders_test.go
+++ b/storageproviders_test.go
@@ -8,24 +8,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMinerVersion(t *testing.T) {
+func TestStorageProviderVersion(t *testing.T) {
 	ctx := context.TODO()
 
 	_, miner, _, fc, closer := initEnsemble(t, ctx)
 	defer closer()
 
-	version, err := fc.MinerByAddress(miner.ActorAddr).Version(ctx)
+	version, err := fc.StorageProviderByAddress(miner.ActorAddr).Version(ctx)
 	require.NoError(t, err)
 	fmt.Printf("Found miner version: %s\n", version)
 
 }
 
-func TestMinerAddressToPeerID(t *testing.T) {
+func TestStorageProviderAddressToPeerID(t *testing.T) {
 	ctx := context.TODO()
 	_, miner, _, fc, closer := initEnsemble(t, ctx)
 	defer closer()
 
-	minerPeerID, err := fc.MinerByAddress(miner.ActorAddr).PeerID(ctx)
+	minerPeerID, err := fc.StorageProviderByAddress(miner.ActorAddr).PeerID(ctx)
 	require.NoError(t, err)
 	fmt.Printf("Mapped miner address %s to peer ID %s\n", miner.ActorAddr, minerPeerID)
 }


### PR DESCRIPTION
closes #3

Note that this changes only Filclient `miner` terminology over to `storage provider`. When naming variables that come from external libraries, we still maintain the original name even if it's `miner`. 